### PR TITLE
Fix sample

### DIFF
--- a/CommunityToolkit_2703_repro/CommunityToolkit_2703_repro/MauiProgram.cs
+++ b/CommunityToolkit_2703_repro/CommunityToolkit_2703_repro/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using CommunityToolkit.Maui;
+using Microsoft.Extensions.Logging;
 
 namespace CommunityToolkit_2703_repro
 {
@@ -9,6 +10,7 @@ namespace CommunityToolkit_2703_repro
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
+                .UseMauiCommunityToolkit()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");

--- a/CommunityToolkit_2703_repro/CommunityToolkit_2703_repro/TestPopup.xaml.cs
+++ b/CommunityToolkit_2703_repro/CommunityToolkit_2703_repro/TestPopup.xaml.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit_2703_repro
             InitializeComponent();
         }
         
-        async Task CloseButton_Clicked(object sender, EventArgs e)
+        async void CloseButton_Clicked(object sender, EventArgs e)
         {
             HttpClient client = new();
             using HttpResponseMessage response1 = await client.GetAsync("https://www.microsoft.com");

--- a/CommunityToolkit_2703_repro/CommunityToolkit_2703_repro/TestPopup.xaml.cs
+++ b/CommunityToolkit_2703_repro/CommunityToolkit_2703_repro/TestPopup.xaml.cs
@@ -5,6 +5,11 @@ namespace CommunityToolkit_2703_repro
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class TestPopup : BooleanPopup
     {
+        public TestPopup()
+        {
+            InitializeComponent();
+        }
+        
         async Task CloseButton_Clicked(object sender, EventArgs e)
         {
             HttpClient client = new();


### PR DESCRIPTION
This introduces 3 key changes to correct some mistakes in the reproduction:

1. Initialises the toolkit using `UseMauiCommunityToolkit`
2. Reintroduces the default constructor in Popup and most importantly the `InitializeComponent` call
3. Correct the event handler method signature to `void`